### PR TITLE
Remove possible UTF-8 BOMs from manifest.json

### DIFF
--- a/src/packages.rs
+++ b/src/packages.rs
@@ -14,6 +14,10 @@ pub trait FromPath {
 
         file.read_to_string(&mut contents)?;
 
+        if contents.contains("\u{feff}") {
+            contents.trim_start_matches("\u{feff}").to_string();
+        }
+    
         Ok(serde_json::from_str(&contents)?)
     }
 }


### PR DESCRIPTION
When manifest.json encoding with UTF-8 with BOM `sfss` will panic.
Just like the following bucket, when you add this bucket and search vcredist, it will be panic
[https://github.com/kkzzhizhou/scoop-apps/blob/master/bucket/vcredist2010.json](https://github.com/kkzzhizhou/scoop-apps/blob/master/bucket/vcredist2010.json)
```
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: Error("expected value", line: 1, column: 1)', src/bin/search.rs:47:57
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```