### PR TITLE
Remove possible UTF-8 BOMs from manifest.json

### DIFF
--- a/src/bin/search.rs
+++ b/src/bin/search.rs
@@ -44,7 +44,7 @@ fn parse_output(file: &DirEntry, bucket: impl AsRef<str>) -> String {
         .read_to_string(&mut buf)
         .unwrap();
 
-    let manifest: Manifest = serde_json::from_str(&buf).unwrap();
+    let manifest: Manifest = serde_json::from_str(&buf.trim_start_matches("\u{feff}")).unwrap();
 
     format!(
         "{} ({}) {}",

--- a/src/packages.rs
+++ b/src/packages.rs
@@ -13,8 +13,8 @@ pub trait FromPath {
         let mut contents = String::new();
 
         file.read_to_string(&mut contents)?;
-
-        Ok(serde_json::from_str(&contents)?)
+        
+        Ok(serde_json::from_str(&contents.trim_start_matches("\u{feff}"))?)
     }
 }
 
@@ -50,7 +50,7 @@ pub fn is_installed(manifest_name: impl AsRef<Path>, bucket: Option<impl AsRef<s
                 .read_to_string(&mut buf)
                 .unwrap();
 
-            let manifest: InstallManifest = serde_json::from_str(&buf).unwrap();
+            let manifest: InstallManifest = serde_json::from_str(&buf.trim_start_matches("\u{feff}")).unwrap();
 
             manifest.bucket == bucket.as_ref()
         } else {


### PR DESCRIPTION
When manifest.json encoding with UTF-8 with BOM `sfss` will panic.
Just like the following bucket, when you add this bucket and search vcredist, it will be panic
[https://github.com/kkzzhizhou/scoop-apps/blob/master/bucket/vcredist2010.json](https://github.com/kkzzhizhou/scoop-apps/blob/master/bucket/vcredist2010.json)
```
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: Error("expected value", line: 1, column: 1)', src/bin/search.rs:47:57
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```