### PR TITLE
Add default value for Manifests to avoid panic when missing field

### DIFF
--- a/src/packages.rs
+++ b/src/packages.rs
@@ -21,6 +21,7 @@ pub trait FromPath {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Manifest {
     /// The version of the package
+    #[serde(default="String::new")]
     pub version: String,
 }
 
@@ -29,6 +30,7 @@ impl FromPath for Manifest {}
 #[derive(Debug, Deserialize, Serialize)]
 pub struct InstallManifest {
     /// The bucket the package was installed from
+    #[serde(default="String::new")]
     pub bucket: String,
 }
 


### PR DESCRIPTION
Add default value(empty string) for Manifest.version and InstallManifest.bucket to avoid panic like #12 