### PR TITLE
Add custom shim implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,9 +738,6 @@ dependencies = [
 [[package]]
 name = "shim"
 version = "0.1.0"
-dependencies = [
- "windows 0.51.1",
-]
 
 [[package]]
 name = "strsim"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,6 +736,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "shim"
+version = "0.1.0"
+dependencies = [
+ "windows 0.51.1",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,11 @@ members = ["sfsu-derive", "shim"]
 [profile.release]
 codegen-units = 1
 
+[profile.shim-release]
+inherits = "release"
+strip = true
+opt-level = 's'
+
 [dependencies]
 anyhow = "1.0"
 chrono = { version = "0.4.31", features = ["serde", "clock", "std"], default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ version = "1.4.13"
 edition = "2021"
 
 [workspace]
-members = ["sfsu-derive"]
+members = ["sfsu-derive", "shim"]
 
 [profile.release]
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,9 @@ codegen-units = 1
 [profile.shim-release]
 inherits = "release"
 strip = true
-opt-level = 's'
+opt-level = "z"
+lto = true
+panic = "abort"
 
 [dependencies]
 anyhow = "1.0"

--- a/shim/Cargo.toml
+++ b/shim/Cargo.toml
@@ -6,4 +6,3 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-windows = { version = "0.51.1", features = ["Win32_System_Environment", "Win32_System_LibraryLoader", "Win32_Foundation"] }

--- a/shim/Cargo.toml
+++ b/shim/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-windows = { version = "0.51.1", features = ["Win32_System_Environment"] }
+windows = { version = "0.51.1", features = ["Win32_System_Environment", "Win32_System_LibraryLoader", "Win32_Foundation"] }

--- a/shim/Cargo.toml
+++ b/shim/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "shim"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+windows = { version = "0.51.1", features = ["Win32_System_Environment"] }

--- a/shim/src/main.rs
+++ b/shim/src/main.rs
@@ -1,4 +1,4 @@
-use std::ffi::OsString;
+use std::{ffi::OsString, path::PathBuf};
 
 use windows::{
     core::PCWSTR,
@@ -42,35 +42,9 @@ const MAX_FILENAME_SIZE: usize = 512;
 //   }
 // }
 
-struct FileName {
-    file_name: [u16; MAX_FILENAME_SIZE + 2],
-}
-
-impl FileName {
-    pub fn load() -> Self {
-        let mut file_name = [0; MAX_FILENAME_SIZE + 2];
-
-        unsafe {
-            GetModuleFileNameW(HMODULE(0), &mut file_name);
-        }
-
-        Self { file_name }
-    }
-}
-
-impl std::fmt::Display for FileName {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let string_lossy = String::from_utf16_lossy(&self.file_name);
-        let trimmed = string_lossy.trim_end_matches('\0');
-
-        write!(f, "{trimmed}")
-    }
-}
-
 fn main() {
     let command_line: PCWSTR = unsafe { GetCommandLineW() };
-    let file_name = FileName::load();
-    dbg!(file_name.to_string());
+    let file_name = std::env::current_exe().unwrap();
 
     println!("Hello, world!");
 }

--- a/shim/src/main.rs
+++ b/shim/src/main.rs
@@ -42,9 +42,25 @@ const MAX_FILENAME_SIZE: usize = 512;
 //   }
 // }
 
+struct ExePath {
+    path: PathBuf,
+}
+
+impl ExePath {
+    pub fn new() -> std::io::Result<Self> {
+        Ok(Self {
+            path: std::env::current_exe()?,
+        })
+    }
+
+    pub fn shim_path(&self) -> PathBuf {
+        self.path.with_extension("shim")
+    }
+}
+
 fn main() {
     let command_line: PCWSTR = unsafe { GetCommandLineW() };
-    let file_name = std::env::current_exe().unwrap();
+    let file_path = ExePath::new().expect("valid executable path");
 
     println!("Hello, world!");
 }

--- a/shim/src/main.rs
+++ b/shim/src/main.rs
@@ -36,5 +36,6 @@ const MAX_FILENAME_SIZE: usize = 512;
 
 fn main() {
     let command_line: PCWSTR = unsafe { GetCommandLineW() };
+    let file_name = GetModuleFileNameW();
     println!("Hello, world!");
 }

--- a/shim/src/main.rs
+++ b/shim/src/main.rs
@@ -1,12 +1,4 @@
-use std::{ffi::OsString, fs::File, path::PathBuf};
-
-use windows::{
-    core::PCWSTR,
-    Win32::{
-        Foundation::HMODULE,
-        System::{Environment::GetCommandLineW, LibraryLoader::GetModuleFileNameW},
-    },
-};
+use std::{env, ffi::OsString, fs::File, path::PathBuf};
 
 const MAX_FILENAME_SIZE: usize = 512;
 
@@ -49,7 +41,7 @@ struct ExePath {
 impl ExePath {
     pub fn new() -> std::io::Result<Self> {
         Ok(Self {
-            path: std::env::current_exe()?,
+            path: env::current_exe()?,
         })
     }
 
@@ -59,7 +51,7 @@ impl ExePath {
 }
 
 fn main() {
-    let command_line: PCWSTR = unsafe { GetCommandLineW() };
+    let args = env::args();
     let file_path = ExePath::new().expect("valid executable path");
 
     let shim_file = File::open(file_path.shim_path()).expect("present and readable shim file");

--- a/shim/src/main.rs
+++ b/shim/src/main.rs
@@ -1,0 +1,40 @@
+use windows::{core::PCWSTR, Win32::System::Environment::GetCommandLineW};
+
+const MAX_FILENAME_SIZE: usize = 512;
+
+// fn compute_program_length(const wchar_t* commandline) -> usize
+// {
+//   int i = 0;
+
+//   if (commandline[0] == L'"') {
+//     // Wait till end of string
+//     i++;
+
+//     for (;;) {
+//       wchar_t c = commandline[i++];
+
+//       if (c == 0)
+//         return i - 1;
+//       else if (c == L'\\')
+//         i++;
+//       else if (c == L'"')
+//         return i;
+//     }
+//   } else {
+//     for (;;) {
+//       wchar_t c = commandline[i++];
+
+//       if (c == 0)
+//         return i - 1;
+//       else if (c == L'\\')
+//         i++;
+//       else if (c == L' ')
+//         return i;
+//     }
+//   }
+// }
+
+fn main() {
+    let command_line: PCWSTR = unsafe { GetCommandLineW() };
+    println!("Hello, world!");
+}

--- a/shim/src/main.rs
+++ b/shim/src/main.rs
@@ -1,4 +1,12 @@
-use windows::{core::PCWSTR, Win32::System::Environment::GetCommandLineW};
+use std::ffi::OsString;
+
+use windows::{
+    core::PCWSTR,
+    Win32::{
+        Foundation::HMODULE,
+        System::{Environment::GetCommandLineW, LibraryLoader::GetModuleFileNameW},
+    },
+};
 
 const MAX_FILENAME_SIZE: usize = 512;
 
@@ -34,8 +42,35 @@ const MAX_FILENAME_SIZE: usize = 512;
 //   }
 // }
 
+struct FileName {
+    file_name: [u16; MAX_FILENAME_SIZE + 2],
+}
+
+impl FileName {
+    pub fn load() -> Self {
+        let mut file_name = [0; MAX_FILENAME_SIZE + 2];
+
+        unsafe {
+            GetModuleFileNameW(HMODULE(0), &mut file_name);
+        }
+
+        Self { file_name }
+    }
+}
+
+impl std::fmt::Display for FileName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let string_lossy = String::from_utf16_lossy(&self.file_name);
+        let trimmed = string_lossy.trim_end_matches('\0');
+
+        write!(f, "{trimmed}")
+    }
+}
+
 fn main() {
     let command_line: PCWSTR = unsafe { GetCommandLineW() };
-    let file_name = GetModuleFileNameW();
+    let file_name = FileName::load();
+    dbg!(file_name.to_string());
+
     println!("Hello, world!");
 }

--- a/shim/src/main.rs
+++ b/shim/src/main.rs
@@ -1,4 +1,4 @@
-use std::{ffi::OsString, path::PathBuf};
+use std::{ffi::OsString, fs::File, path::PathBuf};
 
 use windows::{
     core::PCWSTR,
@@ -61,6 +61,8 @@ impl ExePath {
 fn main() {
     let command_line: PCWSTR = unsafe { GetCommandLineW() };
     let file_path = ExePath::new().expect("valid executable path");
+
+    let shim_file = File::open(file_path.shim_path()).expect("present and readable shim file");
 
     println!("Hello, world!");
 }


### PR DESCRIPTION
The [current shim implementation](https://github.com/71/scoop-better-shimexe) works great, but is is very large (113kb) for what it is. 

This is sort of an experiment to see if I can make a smaller one.