### PR TITLE
Add option to exclude certain commands from the hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5d730647d4fadd988536d06fecce94b7b4f2a7efdae548f1cf4b63205518ab"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
@@ -466,21 +466,11 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
-dependencies = [
- "once_cell",
- "toml_edit 0.19.15",
-]
-
-[[package]]
-name = "proc-macro-crate"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
 dependencies = [
- "toml_edit 0.20.2",
+ "toml_edit",
 ]
 
 [[package]]
@@ -532,11 +522,11 @@ dependencies = [
 
 [[package]]
 name = "quork-proc"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbcf2f711af5855c26efd2888f1b607f9b0ed81ba044dd79c13e1731e0d57fd1"
+checksum = "11c739327e85d9522d6bc96d0ffabcda1e4b36b61ec23d701773ab7511c7ab1e"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -606,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d58da636bd923eae52b7e9120271cbefb16f399069ee566ca5ebf9c30e32238"
+checksum = "465c6fc0621e4abc4187a2bda0937bfd4f722c2730b29562e19689ea796c9a4b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -617,9 +607,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3cbb081b9784b07cceb8824c8583f86db4814d172ab043f3c23f7dc600bf83d"
+checksum = "56d84fdd47036b038fc80dd333d10b6aab10d5d31f4a366e20014def75328d33"
 
 [[package]]
 name = "rustc_version"
@@ -632,9 +622,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.17"
+version = "0.38.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f25469e9ae0f3d0047ca8b93fc56843f38e6774f0914a107ff8b41be8be8e0b7"
+checksum = "745ecfa778e66b2b63c88a61cb36e0eea109e803b0b86bf9879fbc77c70e86ed"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -663,24 +653,24 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad977052201c6de01a8ef2aa3378c4bd23217a056337d1d6da40468d267a4fb0"
+checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -725,7 +715,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "heck",
- "proc-macro-crate 2.0.0",
+ "proc-macro-crate",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -808,17 +798,6 @@ name = "toml_datetime"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
-
-[[package]]
-name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "winnow",
-]
 
 [[package]]
 name = "toml_edit"
@@ -1005,9 +984,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
-version = "0.5.16"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711d82167854aff2018dfd193aa0fef5370f456732f0d5a0c59b0f1b4b907"
+checksum = "a3b801d0e0a6726477cc207f60162da452f3a95adb368399bef20a946e06f65c"
 dependencies = [
  "memchr",
 ]

--- a/sfsu-derive/src/hooks.rs
+++ b/sfsu-derive/src/hooks.rs
@@ -8,7 +8,7 @@ pub fn hook_enum(input: DeriveInput) -> TokenStream {
     let struct_name = {
         let original_ident = &input.ident;
         let og_ident_span = original_ident.span();
-        Ident::new(&format!("{}Raw", original_ident), og_ident_span)
+        Ident::new(&format!("{}Hooks", original_ident), og_ident_span)
     };
 
     let data = &input.data;

--- a/sfsu-derive/src/lib.rs
+++ b/sfsu-derive/src/lib.rs
@@ -11,7 +11,7 @@ pub fn derive_into_inner(input: TokenStream) -> TokenStream {
     inner::into_inner(parse_macro_input!(input as DeriveInput)).into()
 }
 
-#[proc_macro_derive(Hooks)]
+#[proc_macro_derive(Hooks, attributes(no_hook))]
 #[proc_macro_error]
 pub fn derive_hook_enum(input: TokenStream) -> TokenStream {
     hooks::hook_enum(parse_macro_input!(input as DeriveInput)).into()

--- a/sfsu-derive/src/lib.rs
+++ b/sfsu-derive/src/lib.rs
@@ -1,70 +1,18 @@
 use proc_macro::TokenStream;
-use proc_macro2::{Ident, Span};
-use proc_macro_crate::{crate_name, FoundCrate};
-use proc_macro_error::{abort_call_site, proc_macro_error};
-use quote::{quote, ToTokens};
+use proc_macro_error::proc_macro_error;
 use syn::{parse_macro_input, DeriveInput};
 
+mod hooks;
 mod inner;
 
 #[proc_macro_derive(Runnable)]
 #[proc_macro_error]
 pub fn derive_into_inner(input: TokenStream) -> TokenStream {
-    let ast = parse_macro_input!(input as DeriveInput);
-
-    inner::into_inner(ast).into()
+    inner::into_inner(parse_macro_input!(input as DeriveInput)).into()
 }
 
 #[proc_macro_derive(RawEnum)]
 #[proc_macro_error]
 pub fn derive_raw_enum(input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as DeriveInput);
-
-    let struct_name = {
-        let original_ident = &input.ident;
-        let og_ident_span = original_ident.span();
-        Ident::new(&format!("{}Raw", original_ident), og_ident_span)
-    };
-
-    let data = &input.data;
-
-    let mut variants = vec![];
-
-    match data {
-        syn::Data::Enum(ref e) => {
-            for v in &e.variants {
-                variants.push(v.ident.to_token_stream());
-            }
-        }
-        _ => abort_call_site!("Can only be derived for enums"),
-    };
-
-    let command_names = variants
-        .iter()
-        .map(|variant| heck::AsKebabCase(variant.to_string()).to_string())
-        .collect::<Vec<_>>();
-
-    let strum = match crate_name("strum").expect("strum is present in `Cargo.toml`") {
-        FoundCrate::Itself => Ident::new("strum", Span::call_site()),
-        FoundCrate::Name(name) => Ident::new(&name, Span::call_site()),
-    };
-
-    quote! {
-        // TODO: Better way of doing this? or add support for meta in proc macro
-        #[derive(Debug, Clone, #strum::Display, #strum::IntoStaticStr, #strum::EnumIter, PartialEq, Eq)]
-        #[strum(serialize_all = "kebab-case")]
-        pub enum #struct_name {
-            #(#variants),*
-        }
-
-        impl From<String> for #struct_name {
-            fn from(string: String) -> Self {
-                match string.as_str() {
-                    #(#command_names => #struct_name::#variants,)*
-                    _ => panic!("Invalid command name: {}", string),
-                }
-            }
-        }
-    }
-    .into()
+    hooks::hook_enum(parse_macro_input!(input as DeriveInput)).into()
 }

--- a/sfsu-derive/src/lib.rs
+++ b/sfsu-derive/src/lib.rs
@@ -11,8 +11,8 @@ pub fn derive_into_inner(input: TokenStream) -> TokenStream {
     inner::into_inner(parse_macro_input!(input as DeriveInput)).into()
 }
 
-#[proc_macro_derive(RawEnum)]
+#[proc_macro_derive(Hooks)]
 #[proc_macro_error]
-pub fn derive_raw_enum(input: TokenStream) -> TokenStream {
+pub fn derive_hook_enum(input: TokenStream) -> TokenStream {
     hooks::hook_enum(parse_macro_input!(input as DeriveInput)).into()
 }

--- a/sfsu-derive/tests/helpers.rs
+++ b/sfsu-derive/tests/helpers.rs
@@ -1,0 +1,7 @@
+use std::fmt::Display;
+
+use strum::IntoEnumIterator;
+
+pub fn enum_to_string<T: IntoEnumIterator + Display>() -> String {
+    T::iter().map(|v| v.to_string()).collect::<String>()
+}

--- a/sfsu-derive/tests/raw_enum.rs
+++ b/sfsu-derive/tests/raw_enum.rs
@@ -2,7 +2,7 @@
 
 struct DummyStruct;
 
-#[derive(sfsu_derive::RawEnum)]
+#[derive(sfsu_derive::derive_hook_enum)]
 enum EnumWithData {
     Test1(DummyStruct),
     Test2(DummyStruct),

--- a/sfsu-derive/tests/raw_enum.rs
+++ b/sfsu-derive/tests/raw_enum.rs
@@ -1,9 +1,37 @@
 #![allow(dead_code)]
 
+mod helpers;
+
+use sfsu_derive::Hooks;
+
+use helpers::enum_to_string;
+
 struct DummyStruct;
 
-#[derive(sfsu_derive::derive_hook_enum)]
+#[derive(Hooks)]
 enum EnumWithData {
     Test1(DummyStruct),
     Test2(DummyStruct),
+}
+
+#[test]
+fn has_all_variants() {
+    let variants = enum_to_string::<EnumWithDataHooks>();
+
+    assert_eq!(variants, "test1test2");
+}
+
+#[derive(Hooks)]
+enum EnumExclude {
+    Test1(DummyStruct),
+    #[no_hook]
+    Test2(DummyStruct),
+    Test3(DummyStruct),
+}
+
+#[test]
+fn excludes_no_hook_variant() {
+    let variants = enum_to_string::<EnumExcludeHooks>();
+
+    assert_eq!(variants, "test1test3");
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -6,13 +6,13 @@ pub mod unused;
 
 use clap::Subcommand;
 
-use sfsu_derive::{RawEnum, Runnable};
+use sfsu_derive::{Hooks, Runnable};
 
 pub trait Command {
     fn run(self) -> Result<(), anyhow::Error>;
 }
 
-#[derive(Debug, RawEnum, Clone, Subcommand, Runnable)]
+#[derive(Debug, Hooks, Clone, Subcommand, Runnable)]
 pub enum Commands {
     Search(search::Args),
     List(list::Args),

--- a/src/commands/hook.rs
+++ b/src/commands/hook.rs
@@ -15,10 +15,10 @@ enum Shell {
 #[derive(Debug, Clone, Parser)]
 /// Generate hooks for the given shell
 pub struct Args {
-    // TODO: Rename CommandsRaw to CommandHooks or something
+    // TODO: Rename CommandsHooks to CommandHooks or something
     // TODO: Add attribute macro that excludes a variant from the aforementioned enum
     #[clap(short = 'D', long, help = "The commands to disable")]
-    disable: Vec<super::CommandsRaw>,
+    disable: Vec<super::CommandsHooks>,
 
     #[clap(short, long, help = "Print hooks for the given shell", default_value_t = Shell::Powershell)]
     shell: Shell,
@@ -26,7 +26,7 @@ pub struct Args {
 
 impl super::Command for Args {
     fn run(self) -> Result<(), anyhow::Error> {
-        let enabled_hooks: Vec<super::CommandsRaw> = super::CommandsRaw::iter()
+        let enabled_hooks: Vec<super::CommandsHooks> = super::CommandsHooks::iter()
             .filter(|variant| !self.disable.contains(variant))
             .collect();
 

--- a/src/commands/hook.rs
+++ b/src/commands/hook.rs
@@ -15,6 +15,8 @@ enum Shell {
 #[derive(Debug, Clone, Parser)]
 /// Generate hooks for the given shell
 pub struct Args {
+    // TODO: Rename CommandsRaw to CommandHooks or something
+    // TODO: Add attribute macro that excludes a variant from the aforementioned enum
     #[clap(short = 'D', long, help = "The commands to disable")]
     disable: Vec<super::CommandsRaw>,
 


### PR DESCRIPTION
- [x] Rename `CommandsRaw` to more meaningful name about hooks
- [x] Add attribute macro that excludes a variant from the aforementioned enum