### PR TITLE
Enable LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ harness = false
 
 [profile.release]
 codegen-units = 1
+lto = true
 
 [dependencies]
 anyhow = "1.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.75.0"
+channel = "stable"
 targets = ["x86_64-pc-windows-msvc", "i686-pc-windows-msvc"]


### PR DESCRIPTION
- Massively decreases binary size (~1MB)
- Minimal performance gains
- Massive increase in compile time