### PR TITLE
project: use rust nightly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,11 +26,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2.7.3
 
-      - uses: actions-rs/toolchain@v1
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: clippy
 
       - name: Run Clippy
@@ -43,12 +41,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2.7.3
 
-      - name: Install latest stable
-        uses: actions-rs/toolchain@v1
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: rustfmt
 
       - name: Check Formatting
@@ -67,11 +62,8 @@ jobs:
         with:
           buckets: extras java
 
-      - name: Install latest stable
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Build and Test
         run: cargo test
@@ -87,11 +79,8 @@ jobs:
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
       - uses: extractions/setup-just@v2
 
-      - name: Install latest stable
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Build and Package
         run: just release-all

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 [toolchain]
-channel = "stable"
+channel = "nightly-2024-04-10"
 targets = [
-    "x86_64-pc-windows-msvc",
-    "i686-pc-windows-msvc",
     "aarch64-pc-windows-msvc",
+    "i686-pc-windows-msvc",
+    "x86_64-pc-windows-msvc",
 ]


### PR DESCRIPTION
- Fixes [CVE-2024-24576](https://github.com/rust-lang/rust/security/advisories/GHSA-q455-m56c-85mh)
- Allows for use of features present in `manifest-downloads` branch