### PR TITLE
checkup: removed 7zip fallback to 7zip-std as per scoop

### DIFF
--- a/crates/sprinkles/src/diagnostics.rs
+++ b/crates/sprinkles/src/diagnostics.rs
@@ -51,7 +51,7 @@ const EXPECTED_HELPERS: &[Helper] = &[
         exe: "7z",
         name: "7-Zip",
         reason: "unpacking most programs",
-        packages: &["7zip", "7zip-std"],
+        packages: &["7zip"],
     },
     Helper {
         exe: "innounp",


### PR DESCRIPTION
[Relevant release](https://github.com/ScoopInstaller/Scoop/releases/tag/v0.4.0)