### PR TITLE
backup: add command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -754,9 +754,9 @@ checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "flate2"
-version = "1.0.29"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4556222738635b7a3417ae6130d8f52201e45a0c4d1a907f0826383adb5f85e7"
+checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -2353,6 +2353,7 @@ dependencies = [
  "clap",
  "console",
  "criterion",
+ "flate2",
  "futures",
  "git2",
  "human-panic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ clap = { version = "4.5", features = [
     "wrap_help",
 ] }
 console.workspace = true
+flate2 = "1.0.30"
 futures.workspace = true
 git2.workspace = true
 human-panic = "2.0"

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,3 +1,4 @@
+pub mod backup;
 pub mod bucket;
 pub mod cache;
 pub mod cat;
@@ -131,4 +132,7 @@ pub enum Commands {
     #[cfg(feature = "download")]
     /// Show or clear the download cache
     Cache(cache::Args),
+    #[cfg(feature = "beta")]
+    /// Backup the specified app
+    Backup(backup::Args),
 }

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -1,0 +1,17 @@
+use clap::Parser;
+use sprinkles::packages::reference::Package;
+
+#[derive(Debug, Clone, Parser)]
+pub struct Args {
+    #[clap(help = "The package to backup")]
+    package: Package,
+
+    #[clap(from_global)]
+    json: bool,
+}
+
+impl super::Command for Args {
+    async fn runner(self) -> anyhow::Result<()> {
+        todo!()
+    }
+}


### PR DESCRIPTION
This command allows the user to create a compressed bundle for the current version of an app, optionally including persistent data, in a similar vein to steams game backups.