### PR TITLE
fix: handle null value as root_path in scoop config

### DIFF
--- a/crates/sprinkles/src/config.rs
+++ b/crates/sprinkles/src/config.rs
@@ -122,6 +122,7 @@ pub struct Scoop {
     /// Choose scoop shim build
     pub shim: ScoopShim,
 
+    #[serde(deserialize_with = "defaults::deserialize_scoop_root_path")]
     #[serde(default = "defaults::default_scoop_root_path")]
     /// Path to Scoop root directory
     pub root_path: PathBuf,
@@ -223,6 +224,8 @@ impl Scoop {
         let config_path = Self::get_path();
 
         let config = serde_json::to_string_pretty(self)?;
+
+        println!("{config:#?}");
 
         std::fs::write(config_path, config)?;
 

--- a/crates/sprinkles/src/config.rs
+++ b/crates/sprinkles/src/config.rs
@@ -225,8 +225,6 @@ impl Scoop {
 
         let config = serde_json::to_string_pretty(self)?;
 
-        println!("{config:#?}");
-
         std::fs::write(config_path, config)?;
 
         Ok(())

--- a/crates/sprinkles/src/config/defaults.rs
+++ b/crates/sprinkles/src/config/defaults.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use serde::{Deserialize, Deserializer};
+
 // pub fn default_scoop_repo() -> String {
 //     "https://github.com/ScoopInstaller/Scoop".into()
 // }
@@ -12,6 +14,14 @@ pub fn default_scoop_root_path() -> PathBuf {
     );
     path.push("scoop");
     path
+}
+
+pub fn deserialize_scoop_root_path<'de, D>(deserializer: D) -> Result<PathBuf, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let opt = Option::deserialize(deserializer)?;
+    Ok(opt.unwrap_or_else(default_scoop_root_path))
 }
 
 /// Gets the default scoop path


### PR DESCRIPTION
Not sure why this happens, but under certain circumstances the `root_path` becomes null in the json config. 

Serde currently cannot cope with this and fails to (de)serialize the struct so I made a small custom function for it so that turns null into the default path. Certainly not the ideal solution but it's something for now

Directly related to 
- #746