### PR TITLE
remove short flag for debug and dry-run flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Minor internal changes to `VTable` struct
 - Change `app` subcommands hooks to use `app` subcommands
 
+### Removed
+
+- Short `-d` flags for debug and dry-run flags
+
 ## [1.14.0] - 2024-06-12
 
 ### Added

--- a/src/commands/app/purge.rs
+++ b/src/commands/app/purge.rs
@@ -24,7 +24,6 @@ pub struct Args {
     assume_yes: bool,
 
     #[clap(
-        short,
         long,
         help = "Print what would be done, but don't actually do anything"
     )]

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,7 +97,7 @@ struct Args {
     #[clap(short, long, global = true, help = "Show more information in outputs")]
     verbose: bool,
 
-    #[clap(short, long, global = true, help = "Enable debug logging")]
+    #[clap(long, global = true, help = "Enable debug logging")]
     debug: bool,
 
     #[clap(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Simplified command-line interface for the purge command by removing the shorthand option for the `dry_run` flag.
	- Updated the `debug` option to eliminate the short flag, streamlining user input.
	- Introduced a dry run option for the purge command, allowing users to preview actions before execution.
	- Enhanced purge command to handle multiple apps and display both bucket and app names during confirmation.

- **Bug Fixes**
	- Corrected a typo related to a deprecation warning in the changelog.
	- Maintained existing functionality and error handling for purging applications and user confirmations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->