### PR TITLE
Added outdated flag to download command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `app download --outdated` flag to download new versions of all outdated apps
+
+### Changed
+
+- Removed `json` flag from `app download` command
+
 ## [1.15.0] - 2024-03-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Removed `json` flag from `app download` command
+- Download progress bars now show app name instead of url leaf
 
 ## [1.15.0] - 2024-03-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed `json` flag from `app download` command
 - Download progress bars now show app name instead of url leaf
+- Download hash checks now report to a progress bar rather than a print message for each
 
 ## [1.15.0] - 2024-03-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3936,8 +3936,9 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "sprinkles-rs"
-version = "0.17.0"
-source = "git+https://github.com/winpax/sprinkles.git?branch=named-downloads#88e723b47a0b13aa0ffc915a40ef17ba1ea7f84d"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac08abee9fceac0c0621e18ed1024d942feea4ecaa496ef48ad8d167210bb030"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,7 +234,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "syntect",
- "thiserror",
+ "thiserror 1.0.69",
  "unicode-width 0.1.14",
 ]
 
@@ -572,7 +572,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -810,7 +810,7 @@ dependencies = [
  "console",
  "shell-words",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "zeroize",
 ]
 
@@ -1179,7 +1179,7 @@ dependencies = [
  "regex",
  "signal-hook",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1192,7 +1192,7 @@ dependencies = [
  "gix-date",
  "gix-utils",
  "itoa",
- "thiserror",
+ "thiserror 1.0.69",
  "winnow",
 ]
 
@@ -1207,7 +1207,7 @@ dependencies = [
  "gix-object",
  "gix-worktree-stream",
  "jiff",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1223,7 +1223,7 @@ dependencies = [
  "gix-trace",
  "kstring",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "unicode-bom",
 ]
 
@@ -1233,7 +1233,7 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10f78312288bd02052be5dbc2ecbc342c9f4eb791986d86c0a5c06b92dc72efa"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1242,7 +1242,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c28b58ba04f0c004722344390af9dbc85888fbb84be1981afb934da4114d4cf"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1268,7 +1268,7 @@ dependencies = [
  "gix-features",
  "gix-hash",
  "memmap2",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1287,7 +1287,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "unicode-bom",
  "winnow",
 ]
@@ -1302,7 +1302,7 @@ dependencies = [
  "bstr",
  "gix-path",
  "libc",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1319,7 +1319,7 @@ dependencies = [
  "gix-sec",
  "gix-trace",
  "gix-url",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1331,7 +1331,7 @@ dependencies = [
  "bstr",
  "itoa",
  "jiff",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1352,7 +1352,7 @@ dependencies = [
  "gix-traverse",
  "gix-worktree",
  "imara-diff",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1372,7 +1372,7 @@ dependencies = [
  "gix-trace",
  "gix-utils",
  "gix-worktree",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1388,7 +1388,7 @@ dependencies = [
  "gix-path",
  "gix-ref",
  "gix-sec",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1410,7 +1410,7 @@ dependencies = [
  "parking_lot",
  "prodash",
  "sha1_smol",
- "thiserror",
+ "thiserror 1.0.69",
  "walkdir",
 ]
 
@@ -1432,7 +1432,7 @@ dependencies = [
  "gix-trace",
  "gix-utils",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1465,7 +1465,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "952c3a29f1bc1007cc901abce7479943abfa42016db089de33d0a4fa3c85bfe8"
 dependencies = [
  "faster-hex",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1517,7 +1517,7 @@ dependencies = [
  "memmap2",
  "rustix",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1528,7 +1528,7 @@ checksum = "5102acdf4acae2644e38dbbd18cdfba9597a218f7d85f810fe5430207e03c2de"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1540,7 +1540,7 @@ dependencies = [
  "bstr",
  "gix-actor",
  "gix-date",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1561,7 +1561,7 @@ dependencies = [
  "gix-trace",
  "gix-worktree",
  "imara-diff",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1577,7 +1577,7 @@ dependencies = [
  "gix-object",
  "gix-revwalk",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1596,7 +1596,7 @@ dependencies = [
  "gix-validate",
  "itoa",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "winnow",
 ]
 
@@ -1618,7 +1618,7 @@ dependencies = [
  "gix-quote",
  "parking_lot",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1638,7 +1638,7 @@ dependencies = [
  "memmap2",
  "parking_lot",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "uluru",
 ]
 
@@ -1651,7 +1651,7 @@ dependencies = [
  "bstr",
  "faster-hex",
  "gix-trace",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1663,7 +1663,7 @@ dependencies = [
  "bstr",
  "faster-hex",
  "gix-trace",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1676,7 +1676,7 @@ dependencies = [
  "gix-trace",
  "home",
  "once_cell",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1691,7 +1691,7 @@ dependencies = [
  "gix-config-value",
  "gix-glob",
  "gix-path",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1704,7 +1704,7 @@ dependencies = [
  "gix-config-value",
  "parking_lot",
  "rustix",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1721,7 +1721,7 @@ dependencies = [
  "gix-transport",
  "gix-utils",
  "maybe-async",
- "thiserror",
+ "thiserror 1.0.69",
  "winnow",
 ]
 
@@ -1733,7 +1733,7 @@ checksum = "f89f9a1525dcfd9639e282ea939f5ab0d09d93cf2b90c1fc6104f1b9582a8e49"
 dependencies = [
  "bstr",
  "gix-utils",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1753,7 +1753,7 @@ dependencies = [
  "gix-utils",
  "gix-validate",
  "memmap2",
- "thiserror",
+ "thiserror 1.0.69",
  "winnow",
 ]
 
@@ -1768,7 +1768,7 @@ dependencies = [
  "gix-revision",
  "gix-validate",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1786,7 +1786,7 @@ dependencies = [
  "gix-object",
  "gix-revwalk",
  "gix-trace",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1801,7 +1801,7 @@ dependencies = [
  "gix-hashtable",
  "gix-object",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1836,7 +1836,7 @@ dependencies = [
  "gix-pathspec",
  "gix-worktree",
  "portable-atomic",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1851,7 +1851,7 @@ dependencies = [
  "gix-pathspec",
  "gix-refspec",
  "gix-url",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1892,7 +1892,7 @@ dependencies = [
  "gix-sec",
  "gix-url",
  "reqwest",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1909,7 +1909,7 @@ dependencies = [
  "gix-object",
  "gix-revwalk",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1921,7 +1921,7 @@ dependencies = [
  "bstr",
  "gix-features",
  "gix-path",
- "thiserror",
+ "thiserror 1.0.69",
  "url",
 ]
 
@@ -1943,7 +1943,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e187b263461bc36cea17650141567753bc6207d036cedd1de6e81a52f277ff68"
 dependencies = [
  "bstr",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1982,7 +1982,7 @@ dependencies = [
  "gix-path",
  "gix-worktree",
  "io-close",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2000,7 +2000,7 @@ dependencies = [
  "gix-path",
  "gix-traverse",
  "parking_lot",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3271,7 +3271,7 @@ dependencies = [
  "cfg-if",
  "nix",
  "quork-proc",
- "thiserror",
+ "thiserror 1.0.69",
  "windows",
 ]
 
@@ -3370,7 +3370,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3652,7 +3652,7 @@ dependencies = [
  "serde_json",
  "serde_json_path_core",
  "serde_json_path_macros",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3664,7 +3664,7 @@ dependencies = [
  "inventory",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3937,8 +3937,7 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 [[package]]
 name = "sprinkles-rs"
 version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0aa04acd8927ec78a5f593010b9976e791b1c8e4fb4b8d628906fc89fc658b5"
+source = "git+https://github.com/winpax/sprinkles.git?branch=named-downloads#88e723b47a0b13aa0ffc915a40ef17ba1ea7f84d"
 dependencies = [
  "base64",
  "blake3",
@@ -3978,7 +3977,7 @@ dependencies = [
  "strum",
  "sxd-document",
  "sxd-xpath",
- "thiserror",
+ "thiserror 2.0.3",
  "tokio",
  "tokio-util",
  "url",
@@ -4108,7 +4107,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "walkdir",
 ]
 
@@ -4162,7 +4161,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+dependencies = [
+ "thiserror-impl 2.0.3",
 ]
 
 [[package]]
@@ -4170,6 +4178,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4587,7 +4606,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,7 @@ quork = "0.7"
 rayon = "1.10"
 regex = "1.10"
 serde = { version = "1.0", features = ["derive"] }
-sprinkles-rs = { git = "https://github.com/winpax/sprinkles.git", branch = "named-downloads", version = "0.17", features = [
-    "clap",
-] }
+sprinkles-rs = { version = "0.18", features = ["clap"] }
 
 [[bench]]
 harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,9 @@ quork = "0.7"
 rayon = "1.10"
 regex = "1.10"
 serde = { version = "1.0", features = ["derive"] }
-sprinkles-rs = { version = "0.17", features = ["clap"] }
+sprinkles-rs = { git = "https://github.com/winpax/sprinkles.git", branch = "named-downloads", version = "0.17", features = [
+    "clap",
+] }
 
 [[bench]]
 harness = false

--- a/benches/autoupdate.rs
+++ b/benches/autoupdate.rs
@@ -97,7 +97,11 @@ fn criterion_benchmark(c: &mut Criterion) {
             },
             |dl| async {
                 let dl = dl.await;
-                black_box(DownloadHandle::new::<AsyncClient>(dl, None).await.unwrap())
+                black_box(
+                    DownloadHandle::new::<AsyncClient>(dl, None, None)
+                        .await
+                        .unwrap(),
+                )
             },
             BatchSize::SmallInput,
         );

--- a/src/commands/app/download.rs
+++ b/src/commands/app/download.rs
@@ -111,8 +111,6 @@ impl super::Command for Args {
             let result = result?;
 
             if !self.no_hash_check {
-                eprint!("🔓 Checking {} hash...", result.file_name.url);
-
                 let actual_hash = result.actual_hash.no_prefix();
 
                 if result.actual_hash == result.computed_hash {
@@ -124,13 +122,7 @@ impl super::Command for Args {
                         result.computed_hash.no_prefix()
                     );
                 }
-                // } else {
-                //     eprintln!();
-                //     warn!("🔓 No hash provided, skipping hash check");
-                // }
             }
-
-            eprintln!("✅ Downloaded {}", result.file_name.url);
         }
 
         Ok(())

--- a/src/commands/app/download.rs
+++ b/src/commands/app/download.rs
@@ -74,8 +74,11 @@ impl super::Command for Args {
 
                     let downloaders = dl.into_iter().map(|dl| {
                         let mp = mp.clone();
+                        let package_name = package.name();
                         async move {
-                            match DownloadHandle::new::<AsyncClient>(dl, Some(&mp)).await {
+                            match DownloadHandle::new::<AsyncClient>(dl, Some(&mp), package_name)
+                                .await
+                            {
                                 Ok(dl) => anyhow::Ok(dl),
                                 Err(e) => match e {
                                     sprinkles::cache::Error::ErrorCode(status) => {

--- a/src/commands/app/download.rs
+++ b/src/commands/app/download.rs
@@ -2,16 +2,23 @@ use std::time::Duration;
 
 use clap::Parser;
 
+use rayon::prelude::*;
+
 use sprinkles::{
+    buckets::Bucket,
     cache::{DownloadHandle, Handle},
     contexts::ScoopContext,
-    packages::{downloading::Downloader, reference::package},
+    packages::{
+        downloading::Downloader,
+        models::install,
+        reference::{manifest, package},
+    },
     progress::indicatif::{MultiProgress, ProgressBar},
     requests::AsyncClient,
     Architecture,
 };
 
-use crate::{abandon, output::colours::eprintln_yellow};
+use crate::{abandon, models::status::Info, output::colours::eprintln_yellow};
 
 #[derive(Debug, Clone, Parser)]
 /// Download the specified app.
@@ -25,17 +32,23 @@ pub struct Args {
     #[clap(help = "The packages to download")]
     packages: Vec<package::Reference>,
 
-    #[clap(from_global)]
-    json: bool,
+    #[clap(long, help = "Download new versions of all outdated apps")]
+    outdated: bool,
 }
 
 impl super::Command for Args {
     const BETA: bool = true;
 
     async fn runner(self, ctx: &impl ScoopContext) -> Result<(), anyhow::Error> {
-        if self.packages.is_empty() {
-            abandon!("No packages provided")
-        }
+        let packages = if self.packages.is_empty() {
+            if self.outdated {
+                list_outdated(ctx)?
+            } else {
+                abandon!("No packages provided")
+            }
+        } else {
+            self.packages
+        };
 
         if self.no_hash_check {
             eprintln_yellow!(
@@ -49,7 +62,7 @@ impl super::Command for Args {
         pb.enable_steady_tick(Duration::from_millis(100));
 
         let downloaders: Vec<DownloadHandle> =
-            futures::future::try_join_all(self.packages.into_iter().map(|package| {
+            futures::future::try_join_all(packages.into_iter().map(|package| {
                 let mp = mp.clone();
                 async move {
                     let manifest = match package.manifest(ctx).await {
@@ -119,4 +132,36 @@ impl super::Command for Args {
 
         Ok(())
     }
+}
+
+fn list_outdated(ctx: &impl ScoopContext) -> Result<Vec<package::Reference>, anyhow::Error> {
+    let apps = install::Manifest::list_all_unchecked(ctx)?;
+
+    Ok(apps
+        .par_iter()
+        .flat_map(|app| -> anyhow::Result<Info> {
+            if let Some(bucket) = &app.bucket {
+                let local_manifest = app.get_manifest(ctx)?;
+                // TODO: Add the option to check all buckets and find the highest version (will require semver to order versions)
+                let bucket = Bucket::from_name(ctx, bucket)?;
+
+                match Info::from_manifests(ctx, &local_manifest, &bucket) {
+                    Ok(info) => Ok(info),
+                    Err(err) => {
+                        error!(
+                            "Failed to get status for {}: {:?}",
+                            unsafe { app.name() },
+                            err
+                        );
+                        Err(err)?
+                    }
+                }
+            } else {
+                error!("no bucket specified");
+                anyhow::bail!("no bucket specified")
+            }
+        })
+        .filter(|app| app.current != app.available)
+        .map(|app| manifest::Reference::Name(app.name).into_package_ref())
+        .collect::<Vec<_>>())
 }


### PR DESCRIPTION
Waiting on [sprinkles #117](https://github.com/winpax/sprinkles/pull/117), and [v0.18.0](https://github.com/winpax/sprinkles/releases/tag/v0.18.0) release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the `app download --outdated` command to allow users to download new versions of outdated applications.
	- Enhanced download progress bars to display application names for better visibility.
	- Streamlined download hash check reporting using a progress bar.

- **Bug Fixes**
	- Improved error handling for outdated application checks.

- **Documentation**
	- Updated `CHANGELOG.md` to reflect new features and changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->