### PR TITLE
Refactor search command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added config validations.
   - sfsu will now crash with an error message if `no_junction` is enabled.
 - Added `app download --outdated` flag to download new versions of all outdated apps
+- Warnings in search command for deprecated usage
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Download progress bars now show app name instead of url leaf
 - Download hash checks now report to a progress bar rather than a print message for each
 - Logs will now go into `<PWD>/logs` if running with debug assertions
+- `search` command no longer hides `[installed]` label if only searching for installed apps
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - sfsu will now crash with an error message if `no_junction` is enabled.
 - Added `app download --outdated` flag to download new versions of all outdated apps
 - Warnings in search command for deprecated usage
+- Support `json` flag in `search` command
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3759,7 +3759,7 @@ dependencies = [
 
 [[package]]
 name = "sfsu"
-version = "1.15.0"
+version = "1.16.0"
 dependencies = [
  "anyhow",
  "bat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "sfsu"
 publish = true
 repository = "https://github.com/winpax/sfsu"
-version = "1.15.0"
+version = "1.16.0"
 
 [[bench]]
 harness = false

--- a/src/commands/app/download.rs
+++ b/src/commands/app/download.rs
@@ -30,9 +30,6 @@ use crate::{
 #[derive(Debug, Clone, Parser)]
 /// Download the specified app.
 pub struct Args {
-    #[clap(short, long, help = "Use the specified architecture, if the app supports it", default_value_t = Architecture::ARCH)]
-    arch: Architecture,
-
     #[clap(short = 'H', long, help = "Disable hash validation")]
     no_hash_check: bool,
 
@@ -41,6 +38,9 @@ pub struct Args {
 
     #[clap(long, help = "Download new versions of all outdated apps")]
     outdated: bool,
+
+    #[clap(from_global)]
+    arch: Architecture,
 }
 
 impl super::Command for Args {

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -2,7 +2,7 @@ use itertools::Itertools;
 use rayon::prelude::*;
 
 use clap::Parser;
-use regex::Regex;
+use regex::{Match, Regex};
 
 use sprinkles::{
     buckets::Bucket,
@@ -14,7 +14,6 @@ use sprinkles::{
 use crate::{
     calm_panic::CalmUnwrap,
     output::{
-        colours::eprintln_yellow,
         sectioned::{Children, Section, Sections, Text},
         warning,
     },
@@ -40,42 +39,45 @@ impl MatchCriteria {
     /// Check if the name matches
     pub fn matches(
         file_name: &str,
-        manifest: Option<&Manifest>,
-        mode: SearchMode,
         pattern: &Regex,
-        arch: Architecture,
+        list_binaries: impl FnOnce() -> Vec<String>,
+        mode: SearchMode,
     ) -> Self {
-        let file_name = file_name.to_string();
-
         let mut output = MatchCriteria::new();
 
-        if mode.match_names() && pattern.is_match(&file_name) {
-            output.name = true;
+        if mode.match_names() {
+            output.match_names(pattern, file_name);
         }
 
-        if let Some(manifest) = manifest {
-            let binaries = manifest
-                .architecture
-                .merge_default(manifest.install_config.clone(), arch)
-                .bin
-                .map(|b| b.to_vec())
-                .unwrap_or_default();
-
-            let binary_matches = binaries
-                .into_iter()
-                .filter(|binary| pattern.is_match(binary))
-                .filter_map(|b| {
-                    if pattern.is_match(&b) {
-                        Some(b.clone())
-                    } else {
-                        None
-                    }
-                });
-
-            output.bins.extend(binary_matches);
+        if mode.match_binaries() {
+            output.match_binaries(pattern, list_binaries());
         }
 
         output
+    }
+
+    fn match_names(&mut self, pattern: &Regex, file_name: &str) -> &mut Self {
+        if pattern.is_match(file_name) {
+            self.name = true;
+        }
+        self
+    }
+
+    fn match_binaries(&mut self, pattern: &Regex, binaries: Vec<String>) -> &mut Self {
+        let binary_matches = binaries
+            .into_iter()
+            .filter(|binary| pattern.is_match(binary))
+            .filter_map(|b| {
+                if pattern.is_match(&b) {
+                    Some(b.clone())
+                } else {
+                    None
+                }
+            });
+
+        self.bins.extend(binary_matches);
+
+        self
     }
 }
 
@@ -85,79 +87,65 @@ impl Default for MatchCriteria {
     }
 }
 
-pub fn parse_output(
-    manifest: &Manifest,
-    ctx: &impl ScoopContext,
-    bucket: impl AsRef<str>,
-    installed_only: bool,
-    pattern: &Regex,
-    mode: SearchMode,
-    arch: Architecture,
-) -> Option<Section<Text<String>>> {
-    // TODO: Better display of output
+struct MatchedManifest<'m> {
+    manifest: &'m Manifest,
+    bucket: String,
+    installed: bool,
+    name_matched: bool,
+    bins: Vec<String>,
+    exact_match: bool,
+}
 
-    // This may be a bit of a hack, but it works
+impl<'m> MatchedManifest<'m> {
+    pub fn new(
+        ctx: &impl ScoopContext,
+        manifest: &'m Manifest,
+        bucket: impl AsRef<str>,
+        pattern: &Regex,
+        mode: SearchMode,
+        arch: Architecture,
+    ) -> MatchedManifest<'m> {
+        // TODO: Better display of output
 
-    let match_output = MatchCriteria::matches(
-        unsafe { manifest.name() },
-        if mode.match_binaries() {
-            Some(manifest)
-        } else {
-            None
-        },
-        mode,
-        pattern,
-        arch,
-    );
+        let match_output = MatchCriteria::matches(
+            unsafe { manifest.name() },
+            pattern,
+            // Function to list binaries from a manifest
+            // Passed as a closure to avoid this parsing if bin matching isn't required
+            || {
+                manifest
+                    .architecture
+                    .merge_default(manifest.install_config.clone(), arch)
+                    .bin
+                    .map(|b| b.to_vec())
+                    .unwrap_or_default()
+            },
+            mode,
+        );
 
-    if !match_output.name && match_output.bins.is_empty() {
-        return None;
+        let installed = manifest.is_installed(ctx, Some(bucket.as_ref()));
+        let exact_match = unsafe { manifest.name() } == pattern.to_string();
+
+        MatchedManifest {
+            manifest,
+            bucket: bucket.as_ref().to_string(),
+            installed,
+            name_matched: match_output.name,
+            bins: match_output.bins,
+            exact_match,
+        }
     }
 
-    let is_installed = manifest.is_installed(ctx, Some(bucket.as_ref()));
-    if installed_only && !is_installed {
-        return None;
+    pub fn should_match(&self, installed_only: bool) -> bool {
+        if !self.installed && installed_only {
+            return false;
+        }
+        if !self.name_matched && self.bins.is_empty() {
+            return false;
+        }
+
+        true
     }
-
-    let styled_package_name = if unsafe { manifest.name() } == pattern.to_string() {
-        console::style(unsafe { manifest.name() })
-            .bold()
-            .to_string()
-    } else {
-        unsafe { manifest.name() }.to_string()
-    };
-
-    let installed_text = if is_installed && !installed_only {
-        "[installed] "
-    } else {
-        ""
-    };
-
-    let title = format!(
-        "{styled_package_name} ({}) {installed_text}",
-        manifest.version
-    );
-
-    let package = if mode.match_binaries() {
-        let bins = match_output
-            .bins
-            .iter()
-            .map(|output| {
-                Text::new(format!(
-                    "{}{}",
-                    crate::output::WHITESPACE,
-                    console::style(output).bold()
-                ))
-            })
-            .collect_vec();
-
-        Section::new(Children::from(bins))
-    } else {
-        Section::new(Children::None)
-    }
-    .with_title(title);
-
-    Some(package)
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -229,19 +217,21 @@ impl super::Command for Args {
             .par_iter()
             .filter_map(
                 |bucket| match bucket.matches(ctx, self.installed, &pattern, self.mode) {
-                    Ok(manifest) => {
-                        let sections = manifest
+                    Ok(manifests) => {
+                        let sections = manifests
                             .into_par_iter()
-                            .filter_map(|manifest| {
-                                parse_output(
-                                    &manifest,
+                            .map(|manifest| {
+                                MatchedManifest::new(
                                     ctx,
+                                    &manifest,
                                     unsafe { manifest.bucket() },
-                                    self.installed,
                                     &pattern,
                                     self.mode,
                                     Architecture::ARCH,
                                 )
+                            })
+                            .filter(|matched_manifest| {
+                                matched_manifest.should_match(self.installed)
                             })
                             .collect::<Vec<_>>();
 

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -169,6 +169,9 @@ pub struct Args {
 
     #[clap(short, long, help = "Search mode to use", default_value_t)]
     mode: SearchMode,
+
+    #[clap(from_global)]
+    arch: Architecture,
     // TODO: Add json option
     // #[clap(from_global)]
     // json: bool,
@@ -227,7 +230,7 @@ impl super::Command for Args {
                                     unsafe { manifest.bucket() },
                                     &pattern,
                                     self.mode,
-                                    Architecture::ARCH,
+                                    self.arch,
                                 )
                             })
                             .filter(|matched_manifest| {

--- a/src/commands/virustotal.rs
+++ b/src/commands/virustotal.rs
@@ -112,12 +112,7 @@ pub struct Args {
     )]
     filter: Option<Status>,
 
-    #[clap(
-        short,
-        long,
-        help = "Use the specified architecture, if the app supports it",
-        default_value_t = Architecture::ARCH
-    )]
+    #[clap(from_global)]
     arch: Architecture,
 
     #[clap(short = 'A', long, help = "Scan all installed apps")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,10 @@ use clap::Parser;
 
 use commands::{Commands, Runnable};
 use logging::Logger;
-use sprinkles::contexts::{AnyContext, ScoopContext, User};
+use sprinkles::{
+    contexts::{AnyContext, ScoopContext, User},
+    Architecture,
+};
 
 #[cfg(feature = "contexts")]
 use sprinkles::contexts::Global;
@@ -117,6 +120,15 @@ struct Args {
     #[cfg(feature = "contexts")]
     #[clap(short, long, global = true, help = "Use the global Scoop context")]
     global: bool,
+
+    #[clap(
+        short,
+        long,
+        global = true,
+        help = "Use the specified architecture, if the app and command support it",
+        default_value_t = Architecture::ARCH
+    )]
+    arch: Architecture,
 
     #[clap(
         global = true,

--- a/src/output.rs
+++ b/src/output.rs
@@ -12,3 +12,13 @@ pub mod truncate;
 
 /// Opinionated whitespace for formatting
 pub const WHITESPACE: &str = "  ";
+
+#[macro_export]
+#[doc = concat!("Print a colored string with the `yellow` color and a `WARN: ` prefix.")]
+macro_rules! warning {
+    ($($arg:tt)*) => {{
+        $crate::output::colours::eprintln_yellow!("WARN: {}", $crate::output::colours::black!($($arg)*))
+    }};
+}
+
+pub use warning;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a command-line flag `app download --outdated` for downloading outdated applications.
	- Added support for a `json` flag in the search command.
	- Implemented warnings for deprecated usage in the search command.
	- Enhanced logging by directing logs to a specific directory when running with debug assertions.

- **Bug Fixes**
	- Updated download progress bars to display app names instead of URL leaves.
	- Modified the search command to show the `[installed]` label correctly.

- **Documentation**
	- Updated `CHANGELOG.md` to reflect notable changes in the project.

- **Chores**
	- Version updated from `1.15.0` to `1.16.0`. 
	- Removed the `sfsu_macros` crate from the project. 
	- Added a new `warning!` macro for colored warning messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->