### PR TITLE
Fixed ordering in sfsu status command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.17.1]
+
+### Fixed
+
+- Reverse ordering for `sfsu status` command.
+
+## [1.17.0]
+
 ### Added
 
 - Added `app cleanup` command for removing old versions and cache entries
@@ -134,7 +142,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 For older version's changelogs, see the [releases](https://github.com/winpax/sfsu/releases) page.
 
-[Unreleased]: https://github.com/winpax/sfsu/compare/v1.16.0...HEAD
+[Unreleased]: https://github.com/winpax/sfsu/compare/v1.17.1...HEAD
+[1.17.1]: https://github.com/winpax/sfsu/releases/tag/v1.17.1
+[1.17.0]: https://github.com/winpax/sfsu/releases/tag/v1.17.0
 [1.16.0]: https://github.com/winpax/sfsu/releases/tag/v1.16.0
 [1.15.1]: https://github.com/winpax/sfsu/releases/tag/v1.15.1
 [1.15.0]: https://github.com/winpax/sfsu/releases/tag/v1.15.0

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -252,7 +252,7 @@ impl Args {
         if invalid_apps.is_empty() {
             writeln!(output, "All packages are okay and up to date.")?;
         } else {
-            invalid_apps.par_sort_by(|a, b| a.name.cmp(&b.name));
+            invalid_apps.par_sort_by(|prev, curr| curr.name.cmp(&prev.name));
 
             let values = invalid_apps
                 .par_iter()


### PR DESCRIPTION
Closes #1012 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * sfsu status now lists invalid apps in reverse (Z–A) order for improved readability and consistency with expected output.

* **Documentation**
  * Updated changelog with a new 1.17.1 release entry noting the ordering fix.
  * Refreshed “Unreleased” comparison links and added anchors for recent versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->