### PR TITLE
Updates and fixes to `update` and `bucket update` commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `bucket update` command no longer attempts to update scoop
+- `bucket update` command no longer attempts to update Scoop
 - `update` command no longer discourages use
 
 ## [1.17.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `bucket update` command no longer attempts to update scoop
+- `update` command no longer discourages use
+
 ## [1.17.1]
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3978,7 +3978,7 @@ dependencies = [
 
 [[package]]
 name = "sfsu"
-version = "1.17.1"
+version = "1.17.2"
 dependencies = [
  "anyhow",
  "bat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "sfsu"
 publish = true
 repository = "https://github.com/winpax/sfsu"
-version = "1.17.1"
+version = "1.17.2"
 
 [[bench]]
 harness = false

--- a/benches/autoupdate.rs
+++ b/benches/autoupdate.rs
@@ -1,6 +1,6 @@
-use std::{str::FromStr, time::Duration};
+use std::{hint::black_box, str::FromStr, time::Duration};
 
-use criterion::{BatchSize, Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 
 use sprinkles::{
     Architecture,

--- a/benches/ref-matching.rs
+++ b/benches/ref-matching.rs
@@ -1,6 +1,6 @@
-use std::str::FromStr;
+use std::{hint::black_box, str::FromStr};
 
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 
 use sprinkles::{contexts::User, packages::reference::package};
 

--- a/benches/searching.rs
+++ b/benches/searching.rs
@@ -1,4 +1,6 @@
-use criterion::{BatchSize, Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 
 use rayon::prelude::*;
 use regex::Regex;
@@ -19,10 +21,9 @@ fn criterion_benchmark(c: &mut Criterion) {
             black_box(Bucket::list_all(&ctx).unwrap())
                 .par_iter()
                 .filter_map(|bucket| {
-                    match bucket.matches(&ctx, false, &pattern, black_box(SearchMode::Name)) {
-                        Ok(section) => Some(section),
-                        _ => None,
-                    }
+                    bucket
+                        .matches(&ctx, false, &pattern, black_box(SearchMode::Name))
+                        .ok()
                 })
                 .collect::<Vec<_>>();
         })

--- a/benches/serde.rs
+++ b/benches/serde.rs
@@ -1,4 +1,6 @@
-use criterion::{BatchSize, Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 
 use sprinkles::packages::Manifest;
 

--- a/benches/url_parsing.rs
+++ b/benches/url_parsing.rs
@@ -1,4 +1,6 @@
-use criterion::{BatchSize, Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("parse url", |b| {

--- a/src/commands/app/info.rs
+++ b/src/commands/app/info.rs
@@ -50,10 +50,10 @@ pub struct Args {
 impl super::Command for Args {
     async fn runner(mut self, ctx: &impl ScoopContext) -> anyhow::Result<()> {
         #[cfg(not(feature = "v2"))]
-        if self.package.bucket().is_none() {
-            if let Some(bucket) = &self.bucket {
-                self.package.set_bucket(bucket.clone())?;
-            }
+        if self.package.bucket().is_none()
+            && let Some(bucket) = &self.bucket
+        {
+            self.package.set_bucket(bucket.clone())?;
         }
 
         let manifests = self.package.list_manifests(ctx).await?;

--- a/src/commands/bucket/unused.rs
+++ b/src/commands/bucket/unused.rs
@@ -45,7 +45,7 @@ impl commands::Command for Args {
                 let unused =
                     Section::new(unused_buckets).with_title("The following buckets are unused:");
                 println!("{unused}");
-            };
+            }
         }
 
         Ok(())

--- a/src/commands/bucket/update.rs
+++ b/src/commands/bucket/update.rs
@@ -1,3 +1,5 @@
+// TODO: Refactor updating code into separate file for use in both update and bucket update commands
+
 use std::borrow::Cow;
 
 use anyhow::Context;

--- a/src/commands/bucket/update.rs
+++ b/src/commands/bucket/update.rs
@@ -27,7 +27,22 @@ pub struct Args {
 }
 
 impl super::Command for Args {
-    async fn runner(self, ctx: &impl ScoopContext) -> Result<(), anyhow::Error> {
+    async fn runner(
+        self,
+        ctx: &impl ScoopContext<Config = sprinkles::config::Scoop>,
+    ) -> anyhow::Result<()> {
+        self.runner_internal(ctx, false).await
+    }
+}
+
+impl Args {
+    const FINISH_MESSAGE: &'static str = "✅";
+
+    pub async fn runner_internal(
+        self,
+        ctx: &impl ScoopContext,
+        update_scoop: bool,
+    ) -> Result<(), anyhow::Error> {
         let progress_style = style(Some(ProgressOptions::Hide), Some(Message::suffix()));
 
         let buckets = Bucket::list_all(ctx)?;
@@ -41,8 +56,15 @@ impl super::Command for Args {
         // Force checkout to the config's branch
         _ = ctx.outdated().await?;
 
-        let scoop_changelog =
-            self.update_scoop(ctx, longest_bucket_name, progress_style.clone())?;
+        // Only update scoop if `update_scoop` flag is set
+        let scoop_changelog = update_scoop
+            .then(|| {
+                self.update_scoop(ctx, longest_bucket_name, progress_style.clone())
+                    // Flip Result<Option<T>> into Option<Result<T>>
+                    .transpose()
+            })
+            // Flatten Option within Option into single Option<Result<T>>
+            .flatten();
 
         let mp = MultiProgress::new();
 
@@ -73,10 +95,10 @@ impl super::Command for Args {
             println!();
             if let Some(scoop_changelog) = scoop_changelog {
                 let scoop_changelog =
-                    Section::new(Children::from(scoop_changelog)).with_title("Scoop changes:");
+                    Section::new(Children::from(scoop_changelog?)).with_title("Scoop changes:");
 
                 print!("{scoop_changelog}");
-            };
+            }
 
             for bucket_changelog in bucket_changelogs {
                 let (name, changelog) = bucket_changelog;
@@ -94,10 +116,6 @@ impl super::Command for Args {
 
         Ok(())
     }
-}
-
-impl Args {
-    const FINISH_MESSAGE: &'static str = "✅";
 
     fn update_scoop(
         &self,

--- a/src/commands/credits.rs
+++ b/src/commands/credits.rs
@@ -289,24 +289,24 @@ impl Args {
     }
 
     fn handle_events(draw_timer: Option<&Timer>) -> anyhow::Result<bool> {
-        if event::poll(Duration::from_millis(50))? {
-            if let Event::Key(key) = event::read()? {
-                if key.kind == event::KeyEventKind::Press && key.code == KeyCode::Char('q') {
-                    return Ok(true);
+        if event::poll(Duration::from_millis(50))?
+            && let Event::Key(key) = event::read()?
+        {
+            if key.kind == event::KeyEventKind::Press && key.code == KeyCode::Char('q') {
+                return Ok(true);
+            }
+
+            if key.code == KeyCode::Down {
+                if key.kind == event::KeyEventKind::Press
+                    && let Some(draw_timer) = draw_timer
+                {
+                    draw_timer.set_timeout(Duration::from_millis(16));
                 }
 
-                if key.code == KeyCode::Down {
-                    if key.kind == event::KeyEventKind::Press {
-                        if let Some(draw_timer) = draw_timer {
-                            draw_timer.set_timeout(Duration::from_millis(16));
-                        }
-                    }
-
-                    if key.kind == event::KeyEventKind::Release {
-                        if let Some(draw_timer) = draw_timer {
-                            draw_timer.set_timeout(Duration::from_millis(743));
-                        }
-                    }
+                if key.kind == event::KeyEventKind::Release
+                    && let Some(draw_timer) = draw_timer
+                {
+                    draw_timer.set_timeout(Duration::from_millis(743));
                 }
             }
         }
@@ -319,10 +319,10 @@ impl Args {
         title: &str,
         items: &mut VecDeque<Text<'_>>,
     ) -> bool {
-        if let Some(timer) = timer {
-            if timer.tick() {
-                items.pop_front();
-            }
+        if let Some(timer) = timer
+            && timer.tick()
+        {
+            items.pop_front();
         }
 
         let mut footer = "Press Q to exit".to_string();

--- a/src/commands/depends.rs
+++ b/src/commands/depends.rs
@@ -34,7 +34,7 @@ impl super::Command for Args {
 
         if manifests.is_empty() {
             abandon!("Could not find any packages matching: {}", self.package);
-        };
+        }
 
         if self.json {
             println!("{}", serde_json::to_string(&manifests)?);

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -70,7 +70,7 @@ impl super::Command for Args {
                     Command::Scoop => this.handle_scoop(ctx, &value, &mut output).await?,
                     Command::Buckets => this.handle_buckets(ctx, &value, &mut output)?,
                     Command::Apps => this.handle_packages(ctx, &value, &mut output)?,
-                };
+                }
 
                 pb.inc(1);
 

--- a/src/commands/update_alias.rs
+++ b/src/commands/update_alias.rs
@@ -15,8 +15,8 @@ pub struct ArgsWrapper {
 impl super::Command for ArgsWrapper {
     async fn runner(self, ctx: &impl ScoopContext<Config = config::Scoop>) -> anyhow::Result<()> {
         eprintln_yellow!(
-            "Updating buckets has been renamed to `bucket update`. Updating apps is not yet supported and will be added in a future release."
+            "Updating apps is not yet supported and will be added in a future release."
         );
-        bucket::update::Args::runner(self.args, ctx).await
+        bucket::update::Args::runner_internal(self.args, ctx, true).await
     }
 }

--- a/src/commands/virustotal.rs
+++ b/src/commands/virustotal.rs
@@ -251,10 +251,10 @@ impl Args {
         detected: u64,
         total: u64,
     ) -> std::fmt::Result {
-        if let Some(filter) = self.filter {
-            if file_status <= filter {
-                return Ok(());
-            }
+        if let Some(filter) = self.filter
+            && file_status <= filter
+        {
+            return Ok(());
         }
 
         let mut info = format!("{}/{}: {detected}/{total}", manifest.bucket, manifest.name,);
@@ -272,7 +272,7 @@ impl Args {
             Status::Malicious => eprintln_red!("{info}"),
             Status::Suspicious => eprintln_yellow!("{info}"),
             Status::Undetected => eprintln_green!("{info}"),
-        };
+        }
 
         Ok(())
     }

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -228,7 +228,7 @@ impl Diagnostics {
             )?;
         }
 
-        debug!("Filesystem: {:?}", OsString::from_wide(&fs_name));
+        debug!("Filesystem: {}", OsString::from_wide(&fs_name).display());
 
         Ok(fs_name.starts_with(&"NTFS".encode_utf16().collect_vec()))
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,10 @@ use sprinkles::{
 use sprinkles::contexts::Global;
 use validations::Validate;
 
-shadow_rs::shadow!(shadow);
+mod shadow {
+    #![allow(clippy::large_const_arrays)]
+    include!(concat!(env!("OUT_DIR"), "/shadow.rs"));
+}
 
 mod versions {
     pub const SFSU_LONG_VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/long_version.txt"));

--- a/src/models/min.rs
+++ b/src/models/min.rs
@@ -43,10 +43,10 @@ impl Info {
         apps.par_iter()
             .map(Self::from_path)
             .filter(|package| {
-                if let Ok(pkg) = package {
-                    if let Some(bucket) = bucket {
-                        return &pkg.source == bucket;
-                    }
+                if let Ok(pkg) = package
+                    && let Some(bucket) = bucket
+                {
+                    return &pkg.source == bucket;
                 }
                 // Keep errors so that the following line will return the error
                 true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Bucket update now only updates buckets and no longer attempts to update Scoop.
  - Scoop changelog is only shown when present, avoiding empty or misleading changelog sections.
- Style
  - Update command message shortened and clarified; removed discouraging language.
- Documentation
  - Unreleased changelog updated to reflect the bucket update behavior and revised update command messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->