### PR TITLE
Pass refspecs to gix fetch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,7 +139,7 @@ jobs:
         run: just beta-release-all
 
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: package.zip
           path: release/*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1422,9 +1422,9 @@ dependencies = [
 
 [[package]]
 name = "gix"
-version = "0.79.0"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66adef5e4d836ad08bf424dce5e3eb18f51544eee702860419295120dd48811"
+checksum = "5aa56fdbfe98258af2759818ddc3175cc581112660e74c3fd55669836d29a994"
 dependencies = [
  "gix-actor",
  "gix-archive",
@@ -1475,6 +1475,7 @@ dependencies = [
  "gix-worktree",
  "gix-worktree-state",
  "gix-worktree-stream",
+ "nonempty",
  "parking_lot",
  "regex",
  "signal-hook 0.4.3",
@@ -1484,9 +1485,9 @@ dependencies = [
 
 [[package]]
 name = "gix-actor"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c44f13049925e8dc3955c20ecec5391cedfb041e0952416b583ecc57bc68325"
+checksum = "0e5e5b518339d5e6718af108fd064d4e9ba33caf728cf487352873d76411df35"
 dependencies = [
  "bstr",
  "gix-date",
@@ -1496,9 +1497,9 @@ dependencies = [
 
 [[package]]
 name = "gix-archive"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9af6807a2afdc9a447afa2b60c334f7365d97befdc4604cf62d14752260f638d"
+checksum = "12fee3b0b2a30d01ceebd1ff134b187019b5eaedd2901c2e980d7264ee8758dd"
 dependencies = [
  "bstr",
  "gix-date",
@@ -1509,9 +1510,9 @@ dependencies = [
 
 [[package]]
 name = "gix-attributes"
-version = "0.30.1"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e72da5a1c35c9a129be0c60ab9968779981ca50835dd98650ecd8b0ea4d721e"
+checksum = "c233d6eaa098c0ca5ce03236fd7a96e27f1abe72fad74b46003fbd11fe49563c"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -1526,18 +1527,18 @@ dependencies = [
 
 [[package]]
 name = "gix-bitmap"
-version = "0.2.16"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d982fc7ef0608e669851d0d2a6141dae74c60d5a27e8daa451f2a4857bbf41e2"
+checksum = "e7add20f40d060db8c9b1314d499bac6ed7480f33eb113ce3e1cf5d6ff85d989"
 dependencies = [
- "thiserror 2.0.18",
+ "gix-error",
 ]
 
 [[package]]
 name = "gix-blame"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb54e3236eb8ca862e88f2725039556ea5701d9a82a6d089bbf6258ded862a55"
+checksum = "2093922a26722186a2ea36615d581639299ca7d68241d8116d8c441da6f96b1a"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -1555,18 +1556,18 @@ dependencies = [
 
 [[package]]
 name = "gix-chunk"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d14ee09ab454481a91fe969ca5afbd41c8a9b05680197b6554ebb69bdcf7d571"
+checksum = "1096b6608fbe5d27fb4984e20f992b4e76fb8c613f6acb87d07c5831b53a6959"
 dependencies = [
  "gix-error",
 ]
 
 [[package]]
 name = "gix-command"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2962172c6f78731e2b7773bf762f7b8d1746a342a4c0a8914a612206e1295953"
+checksum = "b849c65a609f50d02f8a2774fe371650b3384a743c79c2a070ce0da49b7fb7da"
 dependencies = [
  "bstr",
  "gix-path",
@@ -1577,22 +1578,23 @@ dependencies = [
 
 [[package]]
 name = "gix-commitgraph"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9dc2a550978b510b4e58b0bf5a15481433c3b21981330f3898d93f25b07d9a5"
+checksum = "aea2fcfa6bc7329cd094696ba76682b89bdb61cafc848d91b34abba1c1d7e040"
 dependencies = [
  "bstr",
  "gix-chunk",
  "gix-error",
  "gix-hash",
  "memmap2",
+ "nonempty",
 ]
 
 [[package]]
 name = "gix-config"
-version = "0.52.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db778c8703f3c7f687e03ce22ac8f6eac02adbdafae4cb19d541126fa012524f"
+checksum = "8c24b190bd42b55724368c28ae750840b48e2038b9b5281202de6fca4ec1fce1"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -1623,9 +1625,9 @@ dependencies = [
 
 [[package]]
 name = "gix-credentials"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64b5ef8d1d86b9598df695fd61989e535dc7d139040ed9f31944bc7dcd81b713"
+checksum = "604b2d440d293a0017cbe60ee87fe10337f6e1d224dd6a147619e849e2be4623"
 dependencies = [
  "bstr",
  "gix-command",
@@ -1641,9 +1643,9 @@ dependencies = [
 
 [[package]]
 name = "gix-date"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e66a5117b22495fe7cb4b443777cf3f024a1b1db0009771db440fc8b38a0a6fd"
+checksum = "6c2f2155782090fd947c2f7904166b9f3c3da0d91358adb011f753ea3a55c0ff"
 dependencies = [
  "bstr",
  "gix-error",
@@ -1654,9 +1656,9 @@ dependencies = [
 
 [[package]]
 name = "gix-diff"
-version = "0.59.0"
+version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebee256b21a7d46cec85ab84e824742142a23a21111556a5e50c15796110c6c6"
+checksum = "60592771b104eda4e537c311e8239daef0df651d61e0e21855f7e6166416ff12"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -1679,9 +1681,9 @@ dependencies = [
 
 [[package]]
 name = "gix-dir"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88897d9c3ea961d4b9a1addc466767c127b1f25713d3e054ea32ef02ab7c5db8"
+checksum = "3b483ca64cc32d9e33fa617be153ec90525ad77db51106a5f725805a066dc001"
 dependencies = [
  "bstr",
  "gix-discover",
@@ -1699,9 +1701,9 @@ dependencies = [
 
 [[package]]
 name = "gix-discover"
-version = "0.47.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93103d88576e048a681ebee83e93162972cd4cbce1485a6137cfc98fc0ba152d"
+checksum = "810764b92e8cb95e4d91b7adfc5a14666434fd32ace02900dfb66aae71f845df"
 dependencies = [
  "bstr",
  "dunce",
@@ -1714,9 +1716,9 @@ dependencies = [
 
 [[package]]
 name = "gix-error"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e37b10e97c822fc17550fc1a187283ad3ce79617e920bf179f301ee12abcbc"
+checksum = "f2dfe8025209bf2a72d97a6f2dff105b93e5ebcf131ffa3d3f1728ce4ac3767b"
 dependencies = [
  "bstr",
 ]
@@ -1745,9 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "gix-filter"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "094253121df9aa1cb46d1da0200dd63ebf16263a35f03295109978bf7ed2b483"
+checksum = "7eda328750accaac05ce7637298fd7d6ba0d5d7bdf49c21f899d0b97e3df822d"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -1828,9 +1830,9 @@ dependencies = [
 
 [[package]]
 name = "gix-index"
-version = "0.47.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea450ed666a39676d7e9a41b899487d1645d88053bc8c8cecfca0cf96fcd4a03"
+checksum = "13b28482b86662c8b78160e0750b097a35fd61185803a960681351b3a07de07e"
 dependencies = [
  "bitflags 2.10.0",
  "bstr",
@@ -1867,21 +1869,21 @@ dependencies = [
 
 [[package]]
 name = "gix-mailmap"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "600c608067f76ed496ee46dfb635f1e4eb54360eefea4df6225af0b4413a2f6c"
+checksum = "c7b4818da522786ec7e32a00884ee8fc40fa4c215c3997c0b15f7b62684d1199"
 dependencies = [
  "bstr",
  "gix-actor",
  "gix-date",
- "thiserror 2.0.18",
+ "gix-error",
 ]
 
 [[package]]
 name = "gix-negotiate"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d01c3303ed336b72eb3a48543c028be4650279ff3c3b561f13fa9d2b1979e7"
+checksum = "5a925ec9bc3664eaff9c7dc49bc857fe0de7e90ece6e092cb66ba923812824db"
 dependencies = [
  "bitflags 2.10.0",
  "gix-commitgraph",
@@ -1889,15 +1891,13 @@ dependencies = [
  "gix-hash",
  "gix-object",
  "gix-revwalk",
- "smallvec",
- "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-object"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227e12fad42022ff08d6fbcc4bae34d6e2aa180576e9e1106d9a29a06798e750"
+checksum = "013eae8e072c6155191ac266950dfbc8d162408642571b32e2c6b3e4b03740fb"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -1916,9 +1916,9 @@ dependencies = [
 
 [[package]]
 name = "gix-odb"
-version = "0.76.0"
+version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e84f7e115b2b6615f0c5acddc269598ebc539c363fb276dbd242755a1dd7126c"
+checksum = "f8901a182923799e8857ac01bff6d7c6fecea999abd79a86dab638aadbb843f3"
 dependencies = [
  "arc-swap",
  "gix-features",
@@ -1936,9 +1936,9 @@ dependencies = [
 
 [[package]]
 name = "gix-pack"
-version = "0.66.0"
+version = "0.67.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc20b54d50f64fb02281f2a6c4a24bb9356befdf4535d5a68924575fd67cd5e"
+checksum = "194a9f96f4058359d6874123f160e5b2044974829a29f3a71bb9c9218d1916c3"
 dependencies = [
  "clru",
  "gix-chunk",
@@ -1982,9 +1982,9 @@ dependencies = [
 
 [[package]]
 name = "gix-pathspec"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f4cc23f55ca7c190bf243f1a4e2139d4522022f724fb0dfc06c93f65a01ef6"
+checksum = "40e7636782b35bb1d3ade19ea7387278e96fd49f6963ab41bfca81cef4b61b20"
 dependencies = [
  "bitflags 2.10.0",
  "bstr",
@@ -1997,9 +1997,9 @@ dependencies = [
 
 [[package]]
 name = "gix-prompt"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4806f1ebf969cd54d178ccd975911ef1829aeccea0b27630e63c9d26c8347d7f"
+checksum = "d5b43e9c81bce4e35d90e32405649d47e9fae2ab861d0edbc913fde4df2c6cc7"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -2010,9 +2010,9 @@ dependencies = [
 
 [[package]]
 name = "gix-protocol"
-version = "0.57.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13680c03e847d8f32a59cf1511dd05334d429da33f5af08891367680f15cbca"
+checksum = "5c64ec7b04c57df6e97a2ac4738a4a09897b88febd6ec4bd2c5d3ff3ad3849df"
 dependencies = [
  "bstr",
  "gix-credentials",
@@ -2030,26 +2030,27 @@ dependencies = [
  "gix-transport",
  "gix-utils",
  "maybe-async",
+ "nonempty",
  "thiserror 2.0.18",
  "winnow",
 ]
 
 [[package]]
 name = "gix-quote"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fc2ff2ec8cc0c92807f02eab1f00eb02619fc2810d13dc42679492fcc36757"
+checksum = "68533db71259c8776dd4e770d2b7b98696213ecdc1f5c9e3507119e274e0c578"
 dependencies = [
  "bstr",
+ "gix-error",
  "gix-utils",
- "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-ref"
-version = "0.59.0"
+version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92fd2e86d65efe972a5226f303ed72cfb49a8ad03740e5cc2b27c07970a5d78"
+checksum = "7cc7b230945f02d706a49bcf823b671785ecd9e88e713b8bd2ca5db104c97add"
 dependencies = [
  "gix-actor",
  "gix-features",
@@ -2068,9 +2069,9 @@ dependencies = [
 
 [[package]]
 name = "gix-refspec"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40adba15f8099159d37d0a21e1cfb6602c2e49b6c05f6f8a57a47d0fb21611af"
+checksum = "bb3dc194cdc1176fc20f39f233d0d516f83df843ea14a9eb758a2690f3e38d1e"
 dependencies = [
  "bstr",
  "gix-error",
@@ -2084,9 +2085,9 @@ dependencies = [
 
 [[package]]
 name = "gix-revision"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75ef94c9d76de0765e429ae22a01c512c0d50459269195a90ea11099a5fc752"
+checksum = "df9e31cd402edae08c3fdb67917b9fb75b0c9c9bd2fbed0c2dd9c0847039c556"
 dependencies = [
  "bitflags 2.10.0",
  "bstr",
@@ -2098,13 +2099,14 @@ dependencies = [
  "gix-object",
  "gix-revwalk",
  "gix-trace",
+ "nonempty",
 ]
 
 [[package]]
 name = "gix-revwalk"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07efcad1d064abdac3e79dfc6e23e05accb579559d015e944c9dcf64be95eb49"
+checksum = "573f6e471d76c0796f0b8ed5a431521ea5d121a7860121a2a9703e9434ab1d52"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -2130,21 +2132,22 @@ dependencies = [
 
 [[package]]
 name = "gix-shallow"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189386b5da5285216cc0ede89eff5a943d5261fc794241ee6ec5360b77df15ad"
+checksum = "4ee51037c8a27ddb1c7a6d6db2553d01e501d5b1dae7dc65e41905a70960e658"
 dependencies = [
  "bstr",
  "gix-hash",
  "gix-lock",
+ "nonempty",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-status"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a441e06bff4a4f86ac0b320424193b061ee9c0578448eb9b965fbc96454ca292"
+checksum = "6d4b93da8aae2b5c4ec2aaa3663a0914789737ba17383c665e9270a74173e8f6"
 dependencies = [
  "bstr",
  "filetime",
@@ -2165,9 +2168,9 @@ dependencies = [
 
 [[package]]
 name = "gix-submodule"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac5d38afa855046b7b9e2b85f8cdf7fbf2e449ed061dc81fa7a757abaa38bfac"
+checksum = "6cba2022599491d620fbc77b3729dba0120862ce9b4af6e3c47d19a9f2a5d884"
 dependencies = [
  "bstr",
  "gix-config",
@@ -2201,9 +2204,9 @@ checksum = "f69a13643b8437d4ca6845e08143e847a36ca82903eed13303475d0ae8b162e0"
 
 [[package]]
 name = "gix-transport"
-version = "0.54.0"
+version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9561a98f4f1cada03b565121c475c95d060998082bdb1277044fa6e11fe2aa17"
+checksum = "b4d72f5094b9f851e348f2cbb840d026ffd8119fc28bc2bca1387eecd171c815"
 dependencies = [
  "base64",
  "bstr",
@@ -2220,9 +2223,9 @@ dependencies = [
 
 [[package]]
 name = "gix-traverse"
-version = "0.53.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcdd399f8527f643f8d4fd8de6ec3b6e2c3c826b758b68e90f28275af2e7b33a"
+checksum = "c99b3cf9dc87c13f1404e7b0e8c5e4bff4975d6f788831c02d6c006f3c76b4a0"
 dependencies = [
  "bitflags 2.10.0",
  "gix-commitgraph",
@@ -2237,9 +2240,9 @@ dependencies = [
 
 [[package]]
 name = "gix-url"
-version = "0.35.1"
+version = "0.35.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507752d41afcdf5961ab494eb062c3bf21f68b2ee67e45568e9028cccdd00c34"
+checksum = "d28e8af3d42581190da884f013caf254d2fd4d6ab102408f08d21bfa11de6c8d"
 dependencies = [
  "bstr",
  "gix-path",
@@ -2269,9 +2272,9 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree"
-version = "0.48.0"
+version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93381c5cd37fa208e3f454433425985ea02725369fb33a79ff4ecf7c279f2f98"
+checksum = "005627fc149315f39473e3e94a50058dd5d345c490a23723f67f32ee9c505232"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -2287,9 +2290,9 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree-state"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a521cb82cacfabe8ac5ace4dcf051ffc2282069a6488773351aff70fcef83d9a"
+checksum = "8b9ffce16a83def3651ee4c9872960f4582652fbcc8bbee568c9bae6ffa23894"
 dependencies = [
  "bstr",
  "gix-features",
@@ -2305,9 +2308,9 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree-stream"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9d15b796750ea0c2a48b30dc21403c5cca8bed5e4c8bec8fd111998e0bd570"
+checksum = "805ff4ecc1c8ac02e8d1969521d54cd446fae7397f5db3f4d06c5f0fbaa4dd64"
 dependencies = [
  "gix-attributes",
  "gix-error",
@@ -3274,6 +3277,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonempty"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6"
+
+[[package]]
 name = "ntapi"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4018,7 +4027,7 @@ dependencies = [
  "itertools 0.14.0",
  "kasuari",
  "lru",
- "strum",
+ "strum 0.27.2",
  "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
@@ -4070,7 +4079,7 @@ dependencies = [
  "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
- "strum",
+ "strum 0.27.2",
  "time",
  "unicode-segmentation",
  "unicode-width",
@@ -4751,7 +4760,7 @@ dependencies = [
  "sha1",
  "sha2",
  "shadow-rs",
- "strum",
+ "strum 0.28.0",
  "sxd-document",
  "sxd-xpath",
  "thiserror 2.0.18",
@@ -4940,7 +4949,16 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
 ]
 
 [[package]]
@@ -4948,6 +4966,18 @@ name = "strum_macros"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,12 +76,12 @@ dirs = "6.0"
 dunce = "1.0"
 futures = "0.3"
 git2 = "0.20"
-gix = { version = "0.79", features = [
+gix = { version = "0.80", features = [
     "blocking-http-transport-reqwest",
     "blocking-network-client",
     "worktree-mutation",
 ] }
-gix-object = "0.56"
+gix-object = "0.57"
 glob = "0.3.3"
 hashbrown = "0.16"
 heck = "0.5"
@@ -128,7 +128,7 @@ serde_with = "3.8"
 sha1 = { version = "0.10", optional = true }
 sha2 = { version = "0.10", optional = true }
 shadow-rs = "1.2"
-strum = { version = "0.27", features = ["derive"] }
+strum = { version = "0.28", features = ["derive"] }
 sxd-document = { version = "0.3", optional = true }
 sxd-xpath = { version = "0.4", optional = true }
 thiserror = "2.0"

--- a/src/buckets.rs
+++ b/src/buckets.rs
@@ -25,9 +25,9 @@ use crate::{
 /// Bucket errors
 pub enum Error {
     #[error("Interacting with repo: {0}")]
-    RepoError(#[from] git::Error),
+    Repo(#[from] git::Error),
     #[error("IO Error: {0}")]
-    IOError(#[from] std::io::Error),
+    IO(#[from] std::io::Error),
     #[error("The bucket \"{0}\" does not exist")]
     InvalidBucket(PathBuf),
     #[error("Missing or invalid git output")]

--- a/src/git.rs
+++ b/src/git.rs
@@ -44,7 +44,7 @@ pub enum Error {
     #[error("Git error: {0}")]
     Git2(#[from] git2::Error),
     #[error("{0}")]
-    Gitoxide(Box<errors::GitoxideError>),
+    Gitoxide(Box<errors::GixError>),
     #[error("No remote named {0}")]
     MissingRemote(String),
     #[error("Missing head in remote")]

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,12 +1,6 @@
 //! Scoop git helpers
 
-use std::{
-    ffi::OsStr,
-    fmt::Display,
-    path::{Path, PathBuf},
-    process::Command,
-    sync::atomic::AtomicBool,
-};
+use std::{ffi::OsStr, fmt::Display, path::Path, process::Command, sync::atomic::AtomicBool};
 
 use gix::{
     Commit, ObjectId, Repository, bstr::BStr, remote::ref_map, revision::walk::Sorting,
@@ -20,18 +14,6 @@ pub mod errors;
 pub mod options;
 pub mod parity;
 mod pull;
-
-/// Get the path to the git executable
-///
-/// This is just an alias for [`which::which`]
-///
-/// # Errors
-/// - Git path could not be found
-/// - The current dir and path list were empty
-/// - The found path could not be canonicalized
-pub fn which() -> which::Result<PathBuf> {
-    which::which("git")
-}
 
 #[derive(Debug, thiserror::Error)]
 #[allow(missing_docs)]

--- a/src/git/errors.rs
+++ b/src/git/errors.rs
@@ -3,10 +3,8 @@
 use gix::{date, diff, head, object, open, reference, refspec, remote, revision, traverse};
 
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
-/// A collection of gitoxide errors
-#[error("Gitoxide error: {0}")]
-pub enum GitoxideError {
+#[error("{0}")]
+pub enum GixErrorInner {
     Open(#[from] open::Error),
     Traverse(#[from] traverse::commit::simple::Error),
     RevWalk(#[from] revision::walk::Error),
@@ -30,9 +28,22 @@ pub enum GitoxideError {
     FindRemote(#[from] remote::find::existing::Error),
 }
 
+#[derive(Debug, thiserror::Error)]
+#[error("Gitoxide Error: {0}")]
+pub struct GixError(Box<GixErrorInner>);
+
+impl<T> From<T> for GixError
+where
+    GixErrorInner: From<T>,
+{
+    fn from(value: T) -> Self {
+        Self(Box::new(GixErrorInner::from(value)))
+    }
+}
+
 impl<T> From<T> for super::Error
 where
-    GitoxideError: From<T>,
+    GixError: From<T>,
 {
     fn from(value: T) -> Self {
         Self::Gitoxide(Box::new(value.into()))

--- a/src/git/errors.rs
+++ b/src/git/errors.rs
@@ -1,30 +1,33 @@
 //! Git specific error helpers
 
+use gix::{date, diff, head, object, open, reference, refspec, remote, revision, traverse};
+
 #[derive(Debug, thiserror::Error)]
 #[allow(missing_docs)]
 /// A collection of gitoxide errors
 #[error("Gitoxide error: {0}")]
 pub enum GitoxideError {
-    Open(#[from] gix::open::Error),
-    Traverse(#[from] gix::traverse::commit::simple::Error),
-    RevWalk(#[from] gix::revision::walk::Error),
-    Head(#[from] gix::reference::head_commit::Error),
+    Open(#[from] open::Error),
+    Traverse(#[from] traverse::commit::simple::Error),
+    RevWalk(#[from] revision::walk::Error),
+    Head(#[from] reference::head_commit::Error),
     Decode(#[from] gix_object::decode::Error),
-    RevWalkGraph(#[from] gix::object::find::existing::Error),
-    Commit(#[from] gix::object::commit::Error),
-    Rewrites(#[from] gix::diff::new_rewrites::Error),
-    ObjectPeel(#[from] gix::object::peel::to_kind::Error),
-    ObjectDiff(#[from] gix::object::tree::diff::for_each::Error),
-    FindExisting(#[from] gix::reference::find::existing::Error),
-    FindRemote(#[from] gix::remote::find::existing::Error),
-    RemoteConnection(#[from] gix::remote::connect::Error),
-    PeelCommit(#[from] gix::head::peel::to_commit::Error),
-    RefMap(#[from] gix::remote::ref_map::Error),
-    PrepareFetch(#[from] gix::remote::fetch::prepare::Error),
-    Fetch(#[from] gix::remote::fetch::Error),
-    Revwalk(#[from] gix::revision::walk::iter::Error),
-    DiffOptionsInit(#[from] gix::diff::options::init::Error),
-    DateParse(#[from] gix::date::Error),
+    RevWalkGraph(#[from] object::find::existing::Error),
+    Commit(#[from] object::commit::Error),
+    Rewrites(#[from] diff::new_rewrites::Error),
+    ObjectPeel(#[from] object::peel::to_kind::Error),
+    ObjectDiff(#[from] object::tree::diff::for_each::Error),
+    FindExisting(#[from] reference::find::existing::Error),
+    RemoteConnection(#[from] remote::connect::Error),
+    PeelCommit(#[from] head::peel::to_commit::Error),
+    Fetch(#[from] remote::fetch::Error),
+    Revwalk(#[from] revision::walk::iter::Error),
+    DiffOptionsInit(#[from] diff::options::init::Error),
+    DateParse(#[from] date::Error),
+    RefspecParse(#[from] refspec::parse::Error),
+    RefMap(#[from] remote::ref_map::Error),
+    PrepareFetch(#[from] remote::fetch::prepare::Error),
+    FindRemote(#[from] remote::find::existing::Error),
 }
 
 impl<T> From<T> for super::Error

--- a/src/git/pull.rs
+++ b/src/git/pull.rs
@@ -26,7 +26,7 @@ use gix::{
 
 use crate::{
     contexts::ScoopContext,
-    git::{self, errors::GitoxideError},
+    git::{self, errors::GixError},
 };
 
 pub type ProgressCallback<'a> = &'a dyn Fn(git2::Progress<'_>, bool) -> bool;
@@ -61,7 +61,7 @@ fn do_fetch<'a>(
 fn gix_do_fetch(
     remote: &mut gix::Remote<'_>,
     ref_specs: &[&str],
-) -> Result<remote::fetch::Outcome, GitoxideError> {
+) -> Result<remote::fetch::Outcome, GixError> {
     remote.replace_refspecs(ref_specs, remote::Direction::Fetch)?;
 
     let outcome = remote
@@ -193,7 +193,7 @@ pub fn pull(
     let mut remote = repo
         .gitoxide()
         .find_remote(remote_name)
-        .map_err(git::errors::GitoxideError::from)
+        .map_err(git::errors::GixError::from)
         .map_err(git::Error::from)?;
 
     gix_do_fetch(&mut remote, &[remote_branch])?;

--- a/src/git/pull.rs
+++ b/src/git/pull.rs
@@ -58,9 +58,12 @@ fn do_fetch<'a>(
     repo.reference_to_annotated_commit(&fetch_head)
 }
 
-fn gix_do_fetch<'a>(
-    remote: &'a mut gix::Remote<'_>,
+fn gix_do_fetch(
+    remote: &mut gix::Remote<'_>,
+    ref_specs: &[&str],
 ) -> Result<remote::fetch::Outcome, GitoxideError> {
+    remote.replace_refspecs(ref_specs, remote::Direction::Fetch)?;
+
     let outcome = remote
         .connect(remote::Direction::Fetch)?
         .prepare_fetch(progress::Discard, remote::ref_map::Options::default())?
@@ -190,11 +193,10 @@ pub fn pull(
     let mut remote = repo
         .gitoxide()
         .find_remote(remote_name)
-        .map_err(git::errors::GitoxideError::FindRemote)
-        .map_err(Box::new)
-        .map_err(git::Error::Gitoxide)?;
+        .map_err(git::errors::GitoxideError::from)
+        .map_err(git::Error::from)?;
 
-    gix_do_fetch(&mut remote)?;
+    gix_do_fetch(&mut remote, &[remote_branch])?;
 
     let oid = {
         let commit = repo.latest_remote_commit()?;

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -67,9 +67,9 @@ pub enum Error {
     #[error("Json error: {0}")]
     Json(#[from] json::Error),
     #[error("RDF error: {0}")]
-    RDF(#[from] formats::rdf::RDFError),
+    Rdf(#[from] formats::rdf::RDFError),
     #[error("XML error: {0}")]
-    XML(#[from] formats::xml::XMLError),
+    Xml(#[from] formats::xml::XMLError),
     #[error("Error parsing json: {0}")]
     SerdeJson(#[from] serde_json::Error),
     #[error("Failed to parse url: {0}")]

--- a/src/packages.rs
+++ b/src/packages.rs
@@ -19,7 +19,7 @@ use crate::{
     contexts::ScoopContext,
     git::{
         self, Repo,
-        errors::{self, GitoxideError},
+        errors::{self, GixError},
         parity::Signature,
     },
 };
@@ -175,7 +175,7 @@ pub enum Error {
     #[error("Could not find executable in path: {0}")]
     MissingInPath(#[from] which::Error),
     #[error("Gitoxide error: {0}")]
-    Gitoxide(#[from] Box<errors::GitoxideError>),
+    Gitoxide(#[from] Box<errors::GixError>),
     #[error("Git delta did not have a path")]
     DeltaNoPath,
     #[error("Cannot find git commit where package was updated")]
@@ -201,8 +201,8 @@ pub enum Error {
     MissingParent,
 }
 
-impl From<errors::GitoxideError> for Error {
-    fn from(value: errors::GitoxideError) -> Self {
+impl From<errors::GixError> for Error {
+    fn from(value: errors::GixError) -> Self {
         Self::Gitoxide(Box::new(value))
     }
 }
@@ -711,7 +711,7 @@ impl Manifest {
     /// # Errors
     /// - Git2 errors
     pub fn commit_diff_matches(&self, commit: &gix::Commit<'_>) -> Result<bool> {
-        let tree = commit.tree().map_err(GitoxideError::from)?;
+        let tree = commit.tree().map_err(GixError::from)?;
         let parent_tree = commit
             .parent_ids()
             .find_map(|parent| {
@@ -726,7 +726,7 @@ impl Manifest {
         let mut changed = false;
 
         tree.changes()
-            .map_err(GitoxideError::from)?
+            .map_err(GixError::from)?
             .for_each_to_obtain_tree(&parent_tree, |change| {
                 // Check if the changed file's location starts with the manifest name
                 if change
@@ -735,12 +735,12 @@ impl Manifest {
                     .starts_with(unsafe { self.name() })
                 {
                     changed = true;
-                    return Ok::<_, GitoxideError>(Action::Break(()));
+                    return Ok::<_, GixError>(Action::Break(()));
                 }
 
                 Ok(Action::Continue(()))
             })
-            .map_err(GitoxideError::from)?;
+            .map_err(GixError::from)?;
 
         // Given that the diffoptions ensure that we only match the specific manifest
         // we are safe to return as soon as we find a commit thats changed anything
@@ -831,7 +831,7 @@ impl Manifest {
         let date_time = git::parity::Time::from(
             updated_commit
                 .time()
-                .map_err(git::errors::GitoxideError::from)
+                .map_err(git::errors::GixError::from)
                 .map_err(Box::new)?,
         )
         .to_datetime()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified and simplified Git error handling and reporting for more consistent errors; renamed some public error identifiers and removed a legacy helper function.
* **Bug Fixes**
  * Fixed the Git pull flow to supply and handle fetch refspecs and remote errors correctly.
* **Chores**
  * Updated Git-related dependencies and bumped the CI artifact upload action in the build workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->